### PR TITLE
as doapi is on neoforge for 1.21+, it should use neo conditions

### DIFF
--- a/common/src/main/java/de/cristelknight/doapi/common/recipe/ConditionalRecipe.java
+++ b/common/src/main/java/de/cristelknight/doapi/common/recipe/ConditionalRecipe.java
@@ -119,7 +119,7 @@ public class ConditionalRecipe {
     public static boolean checkCondition(JsonObject c){
         String type = GsonHelper.getAsString(c, "type");
 
-        if(type.equals("forge:mod_loaded")){
+        if(type.equals("neoforge:mod_loaded")){
             String modId = c.get("modid").getAsString();
             return DoApiEP.isModLoaded(modId);
         }


### PR DESCRIPTION
doapi still uses forge conditions for 1.21+, these don't work on neoforge, causing log spam. This PR unifies them back to use the neoforge modid for the type